### PR TITLE
JAWSの点字表示がフラッシュメッセージとして出力されるように修正

### DIFF
--- a/accessible_output2/outputs/jaws.py
+++ b/accessible_output2/outputs/jaws.py
@@ -20,7 +20,7 @@ class Jaws (Output):
 	def braille(self, text, **options):
 		# HACK: replace " with ', Jaws doesn't seem to understand escaping them with \
 		text = text.replace('"', "'")
-		self.object.RunFunction("BrailleString(\"%s\")" % text)
+		self.object.RunFunction("BrailleMessage(\"%s\")" % text)
 
 	def speak(self, text, interrupt=False):
 		self.object.SayString('      %s' % text, interrupt)


### PR DESCRIPTION
Accessible_output2の点字表示機能に変更を加えました。
Accessible_output2で点字を表示させた際、NVDAなどでは点字メッセージとして出力されるため、しばらくすると元の表示に戻りますが、JAWSでは表示内容が上書きされ、手動でタッチカーソルを押さない限り元に戻すことができません。
そこで、「フラッシュメッセージ」として表示されるように変更しました。
この変更を行うと、例えば「msg メッセージ内容」のように表示され、数秒経過するとその表示は消えるようになります。
JAWS本体が出力するメッセージは基本的にはフラッシュメッセージなので、こちらの方が快適に使用できると思われます。
