### PR TITLE
ビルド時のバージョン情報の対応言語に日本語を追加

### DIFF
--- a/tools/baseVersionInfo.txt
+++ b/tools/baseVersionInfo.txt
@@ -39,6 +39,6 @@ VSVersionInfo(
         StringStruct(u'ProductName', u'%PRODUCT_NAME%'),
         StringStruct(u'ProductVersion', u'%PRODUCT_VERSION_TEXT%')])
       ]), 
-    VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
+    VarFileInfo([VarStruct(u'Translation', [1033, 1041])])
   ]
 )


### PR DESCRIPTION
英語米国しかなかったので日本語も追加しました。