### PR TITLE
Bump pyinstaller to v5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ﻿wxpython
 pywin32
 winpaths
-https://github.com/actlaboratory/pyinstaller/archive/refs/tags/v4.8_original.zip
+pyinstaller==5.3
 pyperclip
 requests
 https://github.com/actlaboratory/named-pipe/archive/v1.0.5.zip

--- a/tools/build.py
+++ b/tools/build.py
@@ -57,7 +57,7 @@ class build:
 			exit(-1)
 
 		# 前のビルドをクリーンアップ
-		self.creen(package_path)
+		self.clean(package_path)
 
 		# appveyorでのスナップショットの場合はバージョン番号を一時的に書き換え
 		if build_filename == "snapshot" and appveyor:
@@ -88,7 +88,7 @@ class build:
 			return True
 		return False
 
-	def creen(self,package_path):
+	def clean(self,package_path):
 		if os.path.isdir(package_path):
 			print("Clearling previous build...")
 			shutil.rmtree("dist\\")


### PR DESCRIPTION
changelog: https://pyinstaller.org/en/stable/CHANGES.html#id1
ローカルでは動いたので問題なさそう。
ついでに、ビルドスクリプトのスペルミスを修正。
