### PR TITLE
Bump pyinstaller to 6.3.0

### DIFF
--- a/accessible_output2/__init__.py
+++ b/accessible_output2/__init__.py
@@ -1,4 +1,5 @@
 #2020.09.22 Python3.8対応、platform_util除去対応実施 (yamahubuki)
+#2023.12.31 Pyinstaller 6.3 対応 (cat)
 
 
 from __future__ import absolute_import
@@ -11,8 +12,8 @@ import types
 def load_library(libname, cdll=False):
 	if hasattr(sys,"frozen"):
 		if sys.version_info.major>=3 and sys.version_info.minor>=8:
-			os.add_dll_directory(os.path.join(os.path.abspath(os.path.dirname(sys.executable)), 'accessible_output2', 'lib'))
-		libfile = os.path.join(os.path.abspath(os.path.dirname(sys.executable)), 'accessible_output2', 'lib', libname)
+			os.add_dll_directory(os.path.join(sys._MEIPASS, 'accessible_output2', 'lib'))
+		libfile = os.path.join(sys._MEIPASS, 'accessible_output2', 'lib', libname)
 	else:
 		import inspect
 		module_path=os.path.abspath(os.path.dirname(inspect.getmodule(inspect.stack()[0][0]).__file__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ﻿wxpython==4.2.1
 pywin32
 winpaths
-pyinstaller==5.12
+pyinstaller==6.3.0
 pyperclip
 requests
 https://github.com/actlaboratory/named-pipe/archive/v1.0.5.zip


### PR DESCRIPTION
accessible_output2 だけパッチを当てる必要があったので対応しました。